### PR TITLE
Replace cgi.escape with html.escape due to deprecation warning

### DIFF
--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 
 import re
-import cgi
+import sys
+if sys.version_info < (3, 2):
+    from cgi import escape as html_escape
+else:
+    from html import escape as html_escape
 from itertools import zip_longest
 import urllib.request
 import urllib.parse
@@ -154,7 +158,7 @@ def clean(extractor, text, expand_templates=False, escape_doc=True):
     text = re.sub(r'\n\W+?\n', '\n', text, flags=re.U)  # lines with only punctuations
     text = text.replace(',,', ',').replace(',.', '.')
     if escape_doc:
-        text = cgi.escape(text)
+        text = html_escape(text, quote=False)
     return text
 
 


### PR DESCRIPTION
Related to https://github.com/infolab-csail/WikipediaBase/pull/460, but this time I tried to maintain backwards compatibility. 

CAUTION: I was only able to test this on Python 3 by using it in WikipediaBase. This should be all good to merge for Wikibase in Python 3, but I'm unsure if we care about any other services that depend on wikiextractor having backwards comparability. I haven't tested with any.